### PR TITLE
build: CMakeSettings

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -19,7 +19,6 @@
         { "name": "SOUND",                           "value": "True",                  "type": "BOOL"   },
         { "name": "TESTS",                           "value": "False",                 "type": "BOOL"   },
         { "name": "JSON_FORMAT",                     "value": "ON",                    "type": "BOOL"   },
-        { "name": "CMAKE_RUNTIME_OUTPUT_DIRECTORY",  "value": "${projectDir}",          "type": "PATH"   },
         { "name": "CMAKE_INSTALL_MESSAGE",           "value": "NEVER",                 "type": "STRING" }
       ]
     },
@@ -42,7 +41,6 @@
         { "name": "SOUND",                           "value": "True",                  "type": "BOOL"   },
         { "name": "TESTS",                           "value": "False",                 "type": "BOOL"   },
         { "name": "JSON_FORMAT",                     "value": "ON",                    "type": "BOOL"   },
-        { "name": "CMAKE_RUNTIME_OUTPUT_DIRECTORY",  "value": "${projectDir}",          "type": "PATH"   },
         { "name": "CMAKE_INSTALL_MESSAGE",           "value": "NEVER",                 "type": "STRING" }
       ]
     },
@@ -65,7 +63,6 @@
         { "name": "SOUND",                           "value": "True",                  "type": "BOOL"   },
         { "name": "TESTS",                           "value": "False",                 "type": "BOOL"   },
         { "name": "JSON_FORMAT",                     "value": "ON",                    "type": "BOOL"   },
-        { "name": "CMAKE_RUNTIME_OUTPUT_DIRECTORY",  "value": "${projectDir}",          "type": "PATH"   },
         { "name": "CMAKE_INSTALL_MESSAGE",           "value": "NEVER",                 "type": "STRING" }
       ]
     },
@@ -88,7 +85,6 @@
         { "name": "SOUND",                           "value": "True",                  "type": "BOOL"   },
         { "name": "TESTS",                           "value": "True",                  "type": "BOOL"   },
         { "name": "JSON_FORMAT",                     "value": "OFF",                   "type": "BOOL"   },
-        { "name": "CMAKE_RUNTIME_OUTPUT_DIRECTORY",  "value": "${projectDir}",          "type": "PATH"   },
         { "name": "CMAKE_INSTALL_MESSAGE",           "value": "NEVER",                 "type": "STRING" }
       ]
     },
@@ -111,7 +107,6 @@
         { "name": "SOUND",                           "value": "True",                  "type": "BOOL"   },
         { "name": "TESTS",                           "value": "False",                 "type": "BOOL"   },
         { "name": "JSON_FORMAT",                     "value": "OFF",                   "type": "BOOL"   },
-        { "name": "CMAKE_RUNTIME_OUTPUT_DIRECTORY",  "value": "${projectDir}",          "type": "PATH"   },
         { "name": "CMAKE_INSTALL_MESSAGE",           "value": "NEVER",                 "type": "STRING" },
         { "name": "USE_TRACY",                       "value": "True",                  "type": "BOOL"   },
         { "name": "TRACY_ON_DEMAND",                 "value": "True",                  "type": "BOOL"   },

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,122 @@
+{
+  "configurations": [
+    {
+      "name": "Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${projectDir}/out/build/windows-tiles-sounds-x64-msvc-debug",
+      "installRoot": "${projectDir}/out/install/windows-tiles-sounds-x64-msvc",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "variables": [
+        { "name": "CMAKE_PROJECT_INCLUDE_BEFORE",    "value": "${projectDir}/build-scripts/windows-tiles-sounds-x64-msvc.cmake", "type": "FILEPATH" },
+        { "name": "CMAKE_TOOLCHAIN_FILE",            "value": "${projectDir}/build-scripts/MSVC.cmake",                          "type": "FILEPATH" },
+        { "name": "VCPKG_TARGET_TRIPLET",            "value": "x64-windows-static",   "type": "STRING" },
+        { "name": "DYNAMIC_LINKING",                 "value": "False",                 "type": "BOOL"   },
+        { "name": "CMAKE_EXPORT_COMPILE_COMMANDS",   "value": "ON",                    "type": "BOOL"   },
+        { "name": "CURSES",                          "value": "False",                 "type": "BOOL"   },
+        { "name": "LOCALIZE",                        "value": "True",                  "type": "BOOL"   },
+        { "name": "TILES",                           "value": "True",                  "type": "BOOL"   },
+        { "name": "SOUND",                           "value": "True",                  "type": "BOOL"   },
+        { "name": "TESTS",                           "value": "False",                 "type": "BOOL"   },
+        { "name": "JSON_FORMAT",                     "value": "ON",                    "type": "BOOL"   },
+        { "name": "CMAKE_RUNTIME_OUTPUT_DIRECTORY",  "value": "${projectDir}",          "type": "PATH"   },
+        { "name": "CMAKE_INSTALL_MESSAGE",           "value": "NEVER",                 "type": "STRING" }
+      ]
+    },
+    {
+      "name": "RelWithDebInfo",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "buildRoot": "${projectDir}/out/build/windows-tiles-sounds-x64-msvc-relwithdebinfo",
+      "installRoot": "${projectDir}/out/install/windows-tiles-sounds-x64-msvc",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "variables": [
+        { "name": "CMAKE_PROJECT_INCLUDE_BEFORE",    "value": "${projectDir}/build-scripts/windows-tiles-sounds-x64-msvc.cmake", "type": "FILEPATH" },
+        { "name": "CMAKE_TOOLCHAIN_FILE",            "value": "${projectDir}/build-scripts/MSVC.cmake",                          "type": "FILEPATH" },
+        { "name": "VCPKG_TARGET_TRIPLET",            "value": "x64-windows-static",   "type": "STRING" },
+        { "name": "DYNAMIC_LINKING",                 "value": "False",                 "type": "BOOL"   },
+        { "name": "CMAKE_EXPORT_COMPILE_COMMANDS",   "value": "ON",                    "type": "BOOL"   },
+        { "name": "CURSES",                          "value": "False",                 "type": "BOOL"   },
+        { "name": "LOCALIZE",                        "value": "True",                  "type": "BOOL"   },
+        { "name": "TILES",                           "value": "True",                  "type": "BOOL"   },
+        { "name": "SOUND",                           "value": "True",                  "type": "BOOL"   },
+        { "name": "TESTS",                           "value": "False",                 "type": "BOOL"   },
+        { "name": "JSON_FORMAT",                     "value": "ON",                    "type": "BOOL"   },
+        { "name": "CMAKE_RUNTIME_OUTPUT_DIRECTORY",  "value": "${projectDir}",          "type": "PATH"   },
+        { "name": "CMAKE_INSTALL_MESSAGE",           "value": "NEVER",                 "type": "STRING" }
+      ]
+    },
+    {
+      "name": "Release",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "buildRoot": "${projectDir}/out/build/windows-tiles-sounds-x64-msvc-release",
+      "installRoot": "${projectDir}/out/install/windows-tiles-sounds-x64-msvc",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "variables": [
+        { "name": "CMAKE_PROJECT_INCLUDE_BEFORE",    "value": "${projectDir}/build-scripts/windows-tiles-sounds-x64-msvc.cmake", "type": "FILEPATH" },
+        { "name": "CMAKE_TOOLCHAIN_FILE",            "value": "${projectDir}/build-scripts/MSVC.cmake",                          "type": "FILEPATH" },
+        { "name": "VCPKG_TARGET_TRIPLET",            "value": "x64-windows-static",   "type": "STRING" },
+        { "name": "DYNAMIC_LINKING",                 "value": "False",                 "type": "BOOL"   },
+        { "name": "CMAKE_EXPORT_COMPILE_COMMANDS",   "value": "ON",                    "type": "BOOL"   },
+        { "name": "CURSES",                          "value": "False",                 "type": "BOOL"   },
+        { "name": "LOCALIZE",                        "value": "True",                  "type": "BOOL"   },
+        { "name": "TILES",                           "value": "True",                  "type": "BOOL"   },
+        { "name": "SOUND",                           "value": "True",                  "type": "BOOL"   },
+        { "name": "TESTS",                           "value": "False",                 "type": "BOOL"   },
+        { "name": "JSON_FORMAT",                     "value": "ON",                    "type": "BOOL"   },
+        { "name": "CMAKE_RUNTIME_OUTPUT_DIRECTORY",  "value": "${projectDir}",          "type": "PATH"   },
+        { "name": "CMAKE_INSTALL_MESSAGE",           "value": "NEVER",                 "type": "STRING" }
+      ]
+    },
+    {
+      "name": "Tests",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "buildRoot": "${projectDir}/out/build/windows-tiles-sounds-x64-msvc-tests",
+      "installRoot": "${projectDir}/out/install/windows-tiles-sounds-x64-msvc",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "variables": [
+        { "name": "CMAKE_PROJECT_INCLUDE_BEFORE",    "value": "${projectDir}/build-scripts/windows-tiles-sounds-x64-msvc.cmake", "type": "FILEPATH" },
+        { "name": "CMAKE_TOOLCHAIN_FILE",            "value": "${projectDir}/build-scripts/MSVC.cmake",                          "type": "FILEPATH" },
+        { "name": "VCPKG_TARGET_TRIPLET",            "value": "x64-windows-static",   "type": "STRING" },
+        { "name": "DYNAMIC_LINKING",                 "value": "False",                 "type": "BOOL"   },
+        { "name": "CMAKE_EXPORT_COMPILE_COMMANDS",   "value": "ON",                    "type": "BOOL"   },
+        { "name": "CURSES",                          "value": "False",                 "type": "BOOL"   },
+        { "name": "LOCALIZE",                        "value": "True",                  "type": "BOOL"   },
+        { "name": "TILES",                           "value": "True",                  "type": "BOOL"   },
+        { "name": "SOUND",                           "value": "True",                  "type": "BOOL"   },
+        { "name": "TESTS",                           "value": "True",                  "type": "BOOL"   },
+        { "name": "JSON_FORMAT",                     "value": "OFF",                   "type": "BOOL"   },
+        { "name": "CMAKE_RUNTIME_OUTPUT_DIRECTORY",  "value": "${projectDir}",          "type": "PATH"   },
+        { "name": "CMAKE_INSTALL_MESSAGE",           "value": "NEVER",                 "type": "STRING" }
+      ]
+    },
+    {
+      "name": "Tracy",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "buildRoot": "${projectDir}/out/build/windows-tiles-sounds-x64-msvc-tracy",
+      "installRoot": "${projectDir}/out/install/windows-tiles-sounds-x64-msvc",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "variables": [
+        { "name": "CMAKE_PROJECT_INCLUDE_BEFORE",    "value": "${projectDir}/build-scripts/windows-tiles-sounds-x64-msvc.cmake", "type": "FILEPATH" },
+        { "name": "CMAKE_TOOLCHAIN_FILE",            "value": "${projectDir}/build-scripts/MSVC.cmake",                          "type": "FILEPATH" },
+        { "name": "VCPKG_TARGET_TRIPLET",            "value": "x64-windows-static",   "type": "STRING" },
+        { "name": "DYNAMIC_LINKING",                 "value": "False",                 "type": "BOOL"   },
+        { "name": "CMAKE_EXPORT_COMPILE_COMMANDS",   "value": "ON",                    "type": "BOOL"   },
+        { "name": "CURSES",                          "value": "False",                 "type": "BOOL"   },
+        { "name": "LOCALIZE",                        "value": "True",                  "type": "BOOL"   },
+        { "name": "TILES",                           "value": "True",                  "type": "BOOL"   },
+        { "name": "SOUND",                           "value": "True",                  "type": "BOOL"   },
+        { "name": "TESTS",                           "value": "False",                 "type": "BOOL"   },
+        { "name": "JSON_FORMAT",                     "value": "OFF",                   "type": "BOOL"   },
+        { "name": "CMAKE_RUNTIME_OUTPUT_DIRECTORY",  "value": "${projectDir}",          "type": "PATH"   },
+        { "name": "CMAKE_INSTALL_MESSAGE",           "value": "NEVER",                 "type": "STRING" },
+        { "name": "USE_TRACY",                       "value": "True",                  "type": "BOOL"   },
+        { "name": "TRACY_ON_DEMAND",                 "value": "True",                  "type": "BOOL"   },
+        { "name": "TRACY_ONLY_IPV4",                 "value": "True",                  "type": "BOOL"   }
+      ]
+    }
+  ]
+}

--- a/build-scripts/MSVC.cmake
+++ b/build-scripts/MSVC.cmake
@@ -56,9 +56,8 @@ set(CMAKE_CXX_FLAGS_INIT "\
 /wd4068 /wd4146 /wd4819 /wd6237 /wd6319 /wd26444 /wd26451 /wd26495 /WX- /W1 \
 /TP /Zc:forScope /Zc:inline /Zc:wchar_t"
 )
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT
-"/Oi"
-)
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "/Zi /Oi")
+set(CMAKE_CXX_FLAGS_RELEASE_INIT "/Zi")
 add_compile_definitions(
     _SCL_SECURE_NO_WARNINGS
     _CRT_SECURE_NO_WARNINGS
@@ -67,6 +66,7 @@ add_compile_definitions(
     USE_VCPKG
 )
 add_link_options(
+    /DEBUG
     /OPT:REF
     /OPT:ICF
     /LTCG:OFF

--- a/build-scripts/VsDevCmd.cmake
+++ b/build-scripts/VsDevCmd.cmake
@@ -3,55 +3,110 @@
 VsDevCmd.cmake
 --------------
 
-Run VsDevCmd.bat and extracts environment variables it changes.
-Inject them into the global scope and _MSVC_DEVENV for
-CMakeUserPreset.json at a later step.
+Bootstraps the Visual Studio toolchain environment when CMake is not already
+running inside it (i.e. VSCMD_VER is not set in the environment).
+
+Runs VsDevCmd.bat and captures the environment variables it exports.
+Injects them into the current CMake process scope and populates
+_MSVC_DEVENV for writing into CMakeUserPresets.json at a later step.
+
+This is a no-op when CMake is launched from:
+  - The Visual Studio IDE (File > Open > Folder)
+  - A Visual Studio Developer Command Prompt / PowerShell
+  - A CI environment that pre-configures the VS toolchain
 
 #]=======================================================================]
 
 if("$ENV{VSCMD_VER}" STREQUAL "")
-    # This cmake process is running under VsDevCmd.bat or VS IDE GUI
-    # Avoid to run VsDevCmd.bat twice
+    # Not inside a VS developer environment. Locate VsDevCmd.bat via vswhere.
 
     if ("$ENV{DevEnvDir}" STREQUAL "")
-        # Use Community Edition when not specified
-        file(DOWNLOAD https://github.com/microsoft/vswhere/releases/download/3.0.3/vswhere.exe vswhere.exe
-            TLS_VERIFY ON
-            EXPECTED_HASH SHA1=8569081535767af53811f47c0e6abeabd695f8f4
-            STATUS vswhere
-        )
-        list(GET vswhere 0 vswhere)
-        if("0" EQUAL vswhere)
-            execute_process(COMMAND vswhere.exe -all -latest -property productPath
-                OUTPUT_VARIABLE DevEnvDir
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
-            cmake_path(GET DevEnvDir PARENT_PATH DevEnvDir)
-            set(ENV{DevEnvDir} ${DevEnvDir})
+        # vswhere.exe ships with VS 2017+ at a well-known fixed path.
+        # Prefer it over downloading to avoid network dependencies at configure time.
+        set(_vswhere_installed "$ENV{ProgramFiles\(x86\)}/Microsoft Visual Studio/Installer/vswhere.exe")
+        if(EXISTS "${_vswhere_installed}")
+            set(_vswhere_exe "${_vswhere_installed}")
+            set(_vswhere_found TRUE)
+            message(STATUS "Found vswhere.exe: ${_vswhere_installed}")
         else()
+            # Fall back to downloading vswhere.exe.
+            message(STATUS "vswhere.exe not found at standard location, downloading...")
+            set(_vswhere_download "${CMAKE_BINARY_DIR}/vswhere.exe")
+            file(DOWNLOAD
+                https://github.com/microsoft/vswhere/releases/download/3.0.3/vswhere.exe
+                "${_vswhere_download}"
+                TLS_VERIFY ON
+                EXPECTED_HASH SHA1=8569081535767af53811f47c0e6abeabd695f8f4
+                STATUS _vswhere_status
+            )
+            list(GET _vswhere_status 0 _vswhere_status_code)
+            if("0" EQUAL _vswhere_status_code)
+                set(_vswhere_exe "${_vswhere_download}")
+                set(_vswhere_found TRUE)
+            else()
+                list(GET _vswhere_status 1 _vswhere_error)
+                message(WARNING "Failed to download vswhere.exe: ${_vswhere_error}")
+                set(_vswhere_found FALSE)
+            endif()
+        endif()
+
+        if(_vswhere_found)
+            execute_process(
+                COMMAND "${_vswhere_exe}" -all -latest -property productPath
+                OUTPUT_VARIABLE DevEnvDir
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+            )
+            if(DevEnvDir STREQUAL "")
+                message(WARNING
+                    "vswhere.exe could not find a Visual Studio installation.\n"
+                    "Ensure Visual Studio 2022 with the 'Desktop development with C++' workload is installed.\n"
+                    "If VS is installed, try running cmake from a VS Developer Command Prompt instead."
+                )
+            else()
+                cmake_path(GET DevEnvDir PARENT_PATH DevEnvDir)
+                set(ENV{DevEnvDir} ${DevEnvDir})
+            endif()
+        else()
+            # Last resort: assume the standard VS 2022 Community path.
+            message(WARNING
+                "Could not locate vswhere.exe. Assuming VS 2022 Community Edition.\n"
+                "If your VS installation is elsewhere, set the DevEnvDir environment variable\n"
+                "to your Visual Studio IDE directory (the folder containing devenv.exe)."
+            )
             set(ENV{DevEnvDir} "C:/Program Files/Microsoft Visual Studio/2022/Community/Common7/IDE/")
         endif()
     endif()
 
-    # Run VsDevCmd.bat and set all environment variables it changes
+    # Run VsDevCmd.bat and capture the environment variables it sets.
     set(DevEnvDir $ENV{DevEnvDir})
     cmake_path(APPEND DevEnvDir ../Tools/VsDevCmd.bat OUTPUT_VARIABLE VSDEVCMD_BAT)
     cmake_path(NATIVE_PATH VSDEVCMD_BAT NORMALIZE VSDEVCMD_BAT)
     cmake_path(NATIVE_PATH DevEnvDir NORMALIZE DevEnvDir)
     set(ENV{DevEnvDir} ${DevEnvDir})
     set(ENV{VSDEVCMD_BAT} \"${VSDEVCMD_BAT}\")
-    # Use short DOS path names because of spaces in path names
+
+    if(NOT EXISTS "${VSDEVCMD_BAT}")
+        message(FATAL_ERROR
+            "VsDevCmd.bat not found at: ${VSDEVCMD_BAT}\n"
+            "Ensure Visual Studio 2022 is installed with the 'Desktop development with C++' workload.\n"
+            "Alternatively, open cmake from a VS 2022 Developer Command Prompt."
+        )
+    endif()
+
+    # Use short DOS path names to avoid issues with spaces in the VS install path.
     # See https://gitlab.kitware.com/cmake/cmake/-/issues/16321
     execute_process(COMMAND cmd /c for %A in (%VSDEVCMD_BAT%) do @echo %~sA
         OUTPUT_STRIP_TRAILING_WHITESPACE
         OUTPUT_VARIABLE VSDEVCMD_BAT)
-    # Run it
+
+    message(STATUS "Running VsDevCmd.bat to bootstrap VS environment...")
     execute_process(COMMAND cmd /c ${VSDEVCMD_BAT} -no_logo -arch=amd64 && set
         OUTPUT_STRIP_TRAILING_WHITESPACE
         OUTPUT_VARIABLE _ENV)
-    # This list the environment variables we need.
-    # It is essentially a revised result of:
-    # comm -1 -3 <(sort before.txt) <(sort after.txt) |egrep -o '^[^=]+='"
-    set(_replace 
+
+    # Capture only the environment variables that the VS toolchain adds.
+    # Derived from: comm -1 -3 <(sort before.txt) <(sort after.txt) | grep -o '^[^=]+'
+    set(_replace
         ExtensionSdkDir=
         Framework40Version=
         FrameworkDIR64=
@@ -91,12 +146,12 @@ if("$ENV{VSCMD_VER}" STREQUAL "")
     foreach(_env IN LISTS _ENV)
         string(REGEX MATCH ^[^=]+    _key   "${_env}")
         string(REGEX MATCH =[^\n]+\n _value "${_env}")
-        # We may get some spurious output. Skip the line
+        # Skip lines that are not key=value pairs (e.g. spurious cmd output).
         if(NOT _value MATCHES ^=)
             continue()
         endif()
-        string(SUBSTRING "${_value}" 1 -1 _value) # Removes the = at begin
-        string(STRIP "${_value}" _value) # Remove the \r
+        string(SUBSTRING "${_value}" 1 -1 _value) # Remove leading =
+        string(STRIP "${_value}" _value)           # Remove trailing \r
         list(FIND _replace ${_key}= _idx)
         if(-1 EQUAL _idx)
             continue()
@@ -109,7 +164,8 @@ if("$ENV{VSCMD_VER}" STREQUAL "")
             string(APPEND _MSVC_DEVENV "${_json_entry}")
             continue()
         endif()
-        string(APPEND _MSVC_DEVENV ",\n${_json_entry}")
+        string(APPEND _MSVC_DEVENV ",\n        ${_json_entry}")
     endforeach() # _ENV
-endif() # VSCMD_VER
 
+    message(STATUS "VS environment bootstrapped successfully.")
+endif() # VSCMD_VER

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -9,8 +9,8 @@
       "command": "deno fmt",
       "dependencies": ["docs:gen:cli", "docs:gen:lua"]
     },
-    "docs:gen:cli": "deno run --allow-run=./cataclysm-bn-tiles --allow-write=docs ./scripts/gen_cli_docs.ts --output docs/en/dev/reference/cli_options.md",
-    "docs:gen:lua": "./cataclysm-bn-tiles --lua-doc docs/en/mod/lua/reference/lua.md --lua-types lua_annotations.lua",
+    "docs:gen:cli": "deno run --allow-run=$CATA_EXE --allow-env=CATA_EXE --allow-write=docs ./scripts/gen_cli_docs.ts --output docs/en/dev/reference/cli_options.md",
+    "docs:gen:lua": "$CATA_EXE --lua-doc docs/en/mod/lua/reference/lua.md --lua-types lua_annotations.lua",
     "migrate-unit": "deno run -A scripts/migrate_legacy_unit.ts --path data/json; deno run -A scripts/migrate_legacy_unit.ts --path data/mods; make style-all-json-parallel",
     "dprint": "deno run -A npm:dprint",
     "changelog:reddit": {

--- a/docs/en/dev/guides/building/vs_cmake.md
+++ b/docs/en/dev/guides/building/vs_cmake.md
@@ -1,198 +1,274 @@
-# CMake + Visual Studio + Vcpkg
+# Building with Visual Studio 2022 and CMake
 
-> [!CAUTION]
->
-> CMake build is work-in-progress.
+This guide covers building Cataclysm: Bright Nights on Windows using
+Visual Studio 2022's native CMake integration. After the one-time setup,
+everything — configuration, building, debugging — is done directly inside
+Visual Studio with no external tools required.
+
+> **Legacy build:** The `.sln`-based build in `msvc-full-features/` still works
+> and is untouched by this system. Both can coexist in the same checkout.
+
+## How it works
+
+The project ships two CMake configuration files:
+
+| File                 | Used by              |
+| -------------------- | -------------------- |
+| `CMakeSettings.json` | Visual Studio IDE    |
+| `CMakePresets.json`  | cmake CLI, CI, Linux |
+
+VS reads `CMakeSettings.json` directly when you open the folder. No manual
+cmake configure step is required before opening VS.
+
+> **VS setting:** In **Tools → Options → CMake**, set
+> _"When a CMakeSettings.json or CMakePresets.json file is detected"_ to
+> **"Use CMakeSettings.json (Legacy)"** or **"Never use CMake Presets"**.
+> This ensures VS uses `CMakeSettings.json` and ignores `CMakePresets.json`.
 
 ## Prerequisites
 
-- `cmake` >= 3.24.0
-- `vcpkg` from [vcpkg.io](https://vcpkg.io/en/getting-started.html)
+| Tool                                          | Minimum version | Where to get it                                                   |
+| --------------------------------------------- | --------------- | ----------------------------------------------------------------- |
+| Visual Studio 2022                            | 17.6            | [visualstudio.microsoft.com](https://visualstudio.microsoft.com/) |
+| VS workload: **Desktop development with C++** | —               | VS Installer                                                      |
+| cmake                                         | 3.24            | Included with the VS workload above                               |
+| ninja                                         | any             | Included with the VS workload above                               |
+| vcpkg                                         | any             | Included with VS 2022 17.6+ (see below)                           |
+| git                                           | any             | [git-scm.com](https://git-scm.com/)                               |
 
-Note that starting from Visual Studio 2022 version 17.6, `vcpkg` is included with the distribution
-and is available in the VS developer command prompt, so you don't have to install it separately.
+### vcpkg
 
-## Configure
+Visual Studio 2022 17.6 and later includes vcpkg. If you accepted the
+recommended install options, it is already present. CMake will find it
+automatically through the `VCPKG_INSTALLATION_ROOT` environment variable
+that the VS Developer environment sets.
 
-Configuration can be done using one of the presets in `CMakePresets.json`. They will all build the
-code into the directory `out/build/<preset>/`.
+If you installed a standalone vcpkg separately, set `VCPKG_ROOT` to its
+path and CMake will use that instead.
 
-### Terminal
+---
 
-Ensure that `cmake` can find `vcpkg`. If it can't, it will complain about missing packages. You can
-do this in one of the following ways:
+## Daily workflow in Visual Studio
 
-- For VS2022 users with preinstalled `vcpkg`, `vcpkg` should already be available if you're running
-  the VS developer command prompt and not the plain terminal
-- Append `-DVCPKG_ROOT=C:\dev\vcpkg` (or whatever the path is) to any cmake configure commands
-- Set the environment variable `VCPKG_ROOT` to the path to the vcpkg checkout
-- Add the `VCPKG_ROOT` cache variable in `CMakePresets.json` with the appropriate path (not
-  recommended if you plan to work with the code later, git tracks this file)
+### 1. Open the folder
 
-Run the command
+Open Visual Studio 2022, then **File → Open → Folder…** and select the
+project's root directory (the one containing `CMakeLists.txt`).
 
-```sh
-cmake --list-presets
+Do **not** open a `.sln` file from the `msvc-full-features/` directory —
+that is the legacy build system. Both are separate; do not mix them.
+
+### 2. Select a configuration
+
+In the Standard toolbar, open the **Configuration** drop-down and choose:
+
+| Configuration    | Use when                                      |
+| ---------------- | --------------------------------------------- |
+| `Debug`          | Debugging, all symbols, no optimisation       |
+| `RelWithDebInfo` | Normal development — optimised but debuggable |
+| `Release`        | Performance testing, distribution             |
+| `Tests`          | Building and running the test suite           |
+| `Tracy`          | Performance profiling with the Tracy profiler |
+
+> **RelWithDebInfo** is the best default for day-to-day development.
+> It is optimised (so the game runs at normal speed) but retains enough
+> debug information for breakpoints and stack traces to work reliably.
+
+The `Tests` configuration is a RelWithDebInfo build with the test suite
+enabled. The other configurations have tests disabled to keep build times
+shorter.
+
+The `Tracy` configuration is a Release build with Tracy profiler
+instrumentation compiled in. See [Tracy profiling](#tracy-profiling).
+
+### 3. Build
+
+**Build → Build All** (or `Ctrl+Shift+B`).
+
+The first build downloads and compiles vcpkg dependencies, which takes a
+while. Subsequent builds are incremental.
+
+### 4. Run and debug
+
+Set the startup item in the toolbar to the executable you want:
+
+| Configuration                            | Startup item               |
+| ---------------------------------------- | -------------------------- |
+| Debug / RelWithDebInfo / Release / Tracy | **cataclysm-bn-tiles.exe** |
+| Tests                                    | **cata_test-tiles.exe**    |
+
+Then press **F5**.
+
+The working directory is set to the project root via `launch.vs.json`,
+so the game will find its data files without any additional setup.
+
+---
+
+## Customising your build
+
+To override cmake variables for your local build, open `CMakeSettings.json`
+and add entries to the `variables` array of the configuration you use.
+The file is tracked by git, so for personal overrides either edit a local
+branch or copy the configuration with a new name.
+
+### Useful variables
+
+| Variable      | Default                    | Effect                        |
+| ------------- | -------------------------- | ----------------------------- |
+| `TESTS`       | `OFF` (ON in Tests config) | Build the test suite          |
+| `JSON_FORMAT` | `ON`                       | Build the JSON formatter tool |
+| `LOCALIZE`    | `ON`                       | Build translation support     |
+| `SOUND`       | `ON`                       | Build audio support           |
+
+---
+
+## Tracy profiling
+
+[Tracy](https://github.com/wolfpld/tracy) is a real-time frame profiler.
+Select the **Tracy** configuration in the VS toolbar and build normally.
+Tracy uses `TRACY_ON_DEMAND` mode — the profiler connects and starts
+recording only when the Tracy viewer attaches, so the game is usable
+without the viewer running.
+
+Tracy is also available through the terminal workflow using the
+`windows-tiles-sounds-x64-msvc-tracy` cmake preset — see
+[Terminal workflow](#terminal-workflow).
+
+---
+
+## Terminal workflow
+
+`setup.ps1` validates prerequisites and configures the cmake preset used
+for terminal builds. Run it once from a plain PowerShell window:
+
+```powershell
+.\setup.ps1
 ```
 
-It will show the presets available to you. The list changes based on the environment you are in. If
-empty, the environment is not supported.
+The script checks all prerequisites, downloads the gettext binaries needed
+for building translations, and runs
+`cmake --preset windows-tiles-sounds-x64-msvc`.
 
-Run the command
+After that, the standard cmake commands work from a
+**VS 2022 Developer Command Prompt** or **Developer PowerShell**:
 
-```sh
-cmake --preset <preset>
+```powershell
+# Configure (one time, or after CMakeLists.txt changes)
+cmake --preset windows-tiles-sounds-x64-msvc
+
+# Build
+cmake --build --preset windows-msvc-relwithdebinfo
+
+# Run the game (from the project root directory)
+.\out\build\windows-tiles-sounds-x64-msvc\src\RelWithDebInfo\cataclysm-bn-tiles.exe
+
+# Run tests
+.\out\build\windows-tiles-sounds-x64-msvc\tests\RelWithDebInfo\cata_test-tiles.exe
+
+# Build translations only
+cmake --build --preset windows-msvc-relwithdebinfo --target translations_compile
+
+# Install (copies game + data to a self-contained directory)
+cmake --install out\build\windows-tiles-sounds-x64-msvc --config RelWithDebInfo
 ```
 
-It will download all dependencies and generate build files, as long as `vcpkg` installation is
-available.
+> **Note:** `cmake --build` from a plain terminal (not a VS Developer
+> terminal) relies on the baked VS environment in `CMakeUserPresets.json`.
+> If that file is missing, run `setup.ps1` to regenerate it, or use a
+> VS Developer Command Prompt instead.
 
-If you're using VS2022, be sure to select a preset with `2022` in its name, as presets without that
-suffix will target VS2019.
+---
 
-You can override any option by appending `-Doption=value` to this command, see
-[Build options](./cmake.md/#build-options) in CMake guide. For example, you can disable building of
-tests with `-DTESTS=OFF` if you don't care about them.
+## Troubleshooting
 
-### Visual Studio
+### CMake configure fails immediately
 
-Open the game source folder in Visual Studio.
+**Most common cause:** vcpkg is not found.
 
-Visual Studio should be able to recognize the folder as a CMake project, and may attempt to start
-configuring it, which will most likely fail because it didn't use the proper preset.
-
-The Standard toolbar shows the presets in the `Configuration` drop-down box. Choose the proper one
-(should contain `windows` and `msvc`), then from the main menu, select `Project` ->
-`Configure Cache`.
-
-If you're using VS2022, be sure to select a preset with `2022` in its name, as presets without that
-suffix are targeting VS2019.
-
-## Build
-
-### Terminal
-
-Run the command
-
-- `cmake --build --preset <preset> --config Release`
-
-You can replace `Release` with `Debug` to get a debug build, or `RelWithDebInfo` for a release build
-with less optimizations but more debug information.
-
-### Visual Studio
-
-From the Standard toolbar's `Build Preset` drop-down menu select the build preset. From the main
-menu, select `Build` -> `Build All`.
-
-You can also select between `Release`, `Debug` and `RelWithDebInfo` builds, though depending on UI
-layout the drop-down menu for this may be hidden behind the overflow button.
-
-## Translations
-
-Translations are optional and require `msgfmt` binary from `gettext` package; `vcpkg` should install
-it automatically.
-
-### Terminal
-
-Run the command
-
-- `cmake --build --preset <preset> --target translations_compile`
-
-### Visual Studio
-
-Visual Studio should have built the translations in the previous step. If it did not, open Solution
-Explorer, switch it into CMake Targets mode (can be done with right click), then right click on
-`translations_compile` target -> `Build translations_compile`.
-
-## Install
-
-> [!CAUTION]
->
-> Install is still considered WIP and has received little testing.
-
-### Visual Studio
-
-From the main menu, select `Build` -> `Install CataclysmBN`
-
-### Terminal
-
-Run the command
-
-- `cmake --install out/build/<preset>/ --config Release`
-
-Replace `Release` with your chosen build type.
-
-## Run
-
-The game and test executables will both be available in `.\Release\` folder (folder name matches
-build type, so for other build types you'll get other folder names).
-
-You can run them manually from the terminal, as long as you do it from the project's top directory
-as by default the game expects data files to be in current path.
-
-For running and debugging from Visual Studio, it's recommended to open the generated VS solution
-located at `out\build\<preset>\CataclysmBN.sln` (it will be there regardless of whether you've
-completed previous steps in IDE or terminal) and do any further work with it instead.
-
-Alternatively, it's possible to stay in the "Open Folder" mode, but then you'll have to customize
-launch configuration for the game executable (and tests), and there may be other yet undiscovered
-side effects.
-
-### Terminal
-
-To start the game, run
-
-- `.\Release\cataclysm-bn-tiles.exe`
-
-To execute tests, run
-
-- `.\Release\cata_test-tiles.exe`
-
-### Visual Studio (Option 1, Recommended)
-
-Close Visual Studio, then navigate to `out\build\<preset>\` and open `CataclysmBN.sln`. Set
-`cataclysm-bn-tiles` as Startup Project (can be done with right click from Solution Explorer), and
-you'll be able to run and debug the game executable without additional issues. It will already be
-preconfigured to look for the data files in the top project directory.
-
-To run tests, switch the Startup Project to `cata_test-tiles`.
-
-### Visual Studio (Option 2)
-
-Due to how Visual Studio handles CMake projects, it's impossible to specify the working directory
-for the executable while VS is in the "Open Folder" mode. This StackOverflow answer explains it
-nicely: https://stackoverflow.com/a/62309569 Fortunately, VS allows customizing exe launch options
-on individual basis.
-
-Open solution explorer and switch it into CMake Targets mode if you haven't already (can be done
-with a right click). There, right click on the `cataclysm-bn-tiles` target ->
-`Add Debug Configuration`. Visual Studio will open launch configurations file for this project, with
-new configuration for the `cataclysm-bn-tiles` target. Add the following line:
+Check that `VCPKG_ROOT` is set (or that VS's bundled vcpkg is available).
+Open a VS Developer Command Prompt and run:
 
 ```
-"currentDir": "${workspaceRoot}",
+echo %VCPKG_ROOT%
+echo %VCPKG_INSTALLATION_ROOT%
 ```
 
-to the config and save the file.
+At least one should point to a directory containing `vcpkg.exe`. If
+neither is set, run `setup.ps1` — it locates the VS-bundled vcpkg
+automatically.
 
-The final result should look something like this:
+### VS shows an `x64-Debug` configuration or the ncurses error appears
 
-```json
-{
-  "version": "0.2.1",
-  "defaults": {},
-  "configurations": [
-    {
-      "currentDir": "${workspaceRoot}",
-      "type": "default",
-      "project": "CMakeLists.txt",
-      "projectTarget": "cataclysm-bn-tiles.exe (<PATH_TO_SOURCE_FOLDER>\\Debug\\cataclysm-bn-tiles.exe)",
-      "name": "cataclysm-bn-tiles.exe (<PATH_TO_SOURCE_FOLDER>\\Debug\\cataclysm-bn-tiles.exe)"
-    }
-  ]
-}
+VS is not using `CMakeSettings.json`. Go to
+**Tools → Options → CMake → General** and set the preset integration
+to **"Use CMakeSettings.json (Legacy)"** or **"Never use CMake Presets"**.
+Then do a full reset (see below).
+
+### Configure succeeds but build fails with missing headers/libs
+
+The VS environment (INCLUDE, LIB, PATH) may not have been captured
+correctly. Try:
+
+1. Delete `CMakeUserPresets.json` from the project root.
+2. Delete the relevant `out\build\` subdirectory entirely.
+3. Run `setup.ps1` again to regenerate both.
+
+### Game launches but immediately crashes / can't find data
+
+`launch.vs.json` at the project root sets the working directory to the
+project root for F5 launches. If the file is missing or VS is not reading
+it, the game may not find `./data/`.
+
+If you are launching the `.exe` directly from File Explorer or a terminal,
+make sure to run it from the project root directory:
+
+```powershell
+# Correct — run from the project root
+.\out\build\windows-tiles-sounds-x64-msvc-relwithdebinfo\src\cataclysm-bn-tiles.exe
+
+# Wrong — game can't find ./data/
+cd out\build\windows-tiles-sounds-x64-msvc-relwithdebinfo\src
+.\cataclysm-bn-tiles.exe
 ```
 
-Now, you should be able to run and debug the game executable from inside Visual Studio.
+### "VsDevCmd.bat not found" error during configure
 
-If you'd like to run tests, repeat this process for the `cata_test-tiles` target.
+`VsDevCmd.bat` is inside your VS installation. If this error appears, VS
+may be installed in a non-standard location. Set the `DevEnvDir`
+environment variable to the path of your VS `Common7\IDE` directory before
+running cmake:
+
+```powershell
+$env:DevEnvDir = "D:\VisualStudio\Common7\IDE\"
+cmake --preset windows-tiles-sounds-x64-msvc
+```
+
+### Builds are very slow
+
+ccache is detected and used automatically if it is installed and on
+`PATH`. Install it from [ccache.dev](https://ccache.dev/) to dramatically
+speed up incremental builds after `git clean` or branch switches.
+
+### How to fully reset the build environment
+
+If things are broken and you want a clean slate:
+
+```powershell
+# Delete VS's cached project state (stale configurations, IntelliSense DB)
+Remove-Item -Recurse -Force .vs
+
+# Delete all build output directories
+Remove-Item -Recurse -Force out\build
+
+# Delete the generated user presets (will be regenerated on next configure)
+Remove-Item -Force CMakeUserPresets.json
+
+# Re-run setup for terminal builds (VS will reconfigure itself on next open)
+.\setup.ps1
+```
+
+### CMakeUserPresets.json shows "already exists" on reconfigure
+
+This is intentional. The file is only generated on first configure to
+avoid overwriting your customisations. If you want to reset it to the
+default generated content, delete it and run `setup.ps1`.

--- a/docs/en/dev/reference/cli_options.md
+++ b/docs/en/dev/reference/cli_options.md
@@ -15,112 +15,176 @@ but also provides a number of command line options to help modders and developer
 
 ## Info
 
-### `--help`
+### `--help
+
+`
 
 print this message and exit.
 
-### `--version`
+### `--version
+
+`
 
 print the version and exit.
 
-### `--paths`
+### `--paths
+
+`
 
 print the paths used by the game and exit.
 
-## Command line parameters
+### `
 
-### `--seed <string of letters and or numbers>`
+`
+
+Command line parameters:.
+
+### `--seed <string of letters and or numbers>
+
+`
 
 Sets the random number generator's seed value.
 
-### `--jsonverify`
+### `--jsonverify
+
+`
 
 Checks the BN json files.
 
-### `--check-mods [mods…]`
+### `--check-mods [mods…]
+
+`
 
 Checks the json files belonging to BN mods.
 
-### `--dump-stats <what> [mode = TSV] [opts…]`
+### `--dump-stats <what> [mode = TSV] [opts…]
+
+`
 
 Dumps item stats.
 
-### `--world <name>`
+### `--world <name>
+
+`
 
 Load world.
 
-### `--basepath <path>`
+### `--basepath <path>
+
+`
 
 Base path for all game data subdirectories.
 
-### `--dont-debugmsg`
+### `--dont-debugmsg
+
+`
 
 If set, no debug messages will be printed.
 
-### `--lua-doc <output path>`
+### `--lua-doc <output path>
+
+`
 
 Generate Lua docs to given path and exit.
 
-### `--lua-types <output path>`
+### `--lua-types <output path>
+
+`
 
 Generate Lua types to given path and exit.
 
-### `--datadir <directory name>`
+### `--datadir <directory name>
+
+`
 
 Sub directory from which game data is loaded.
 
-### `--autopickupfile <filename>`
+### `--autopickupfile <filename>
+
+`
 
 Name of the autopickup options file within the configdir.
 
-### `--motdfile <filename>`
+### `--motdfile <filename>
+
+`
 
 Name of the message of the day file within the motd directory.
 
-## Map sharing
+### `
 
-### `--shared`
+`
+
+Map sharing.
+
+### `--shared
+
+`
 
 Activates the map-sharing mode.
 
-### `--username <name>`
+### `--username <name>
+
+`
 
 Instructs map-sharing code to use this name for your character..
 
-### `--addadmin <username>`
+### `--addadmin <username>
+
+`
 
 Instructs map-sharing code to use this name for your character and give you access to the cheat functions..
 
-### `--adddebugger <username>`
+### `--adddebugger <username>
+
+`
 
 Informs map-sharing code that you're running inside a debugger.
 
-### `--competitive`
+### `--competitive
+
+`
 
 Instructs map-sharing code to disable access to the in-game cheat functions.
 
-### `--worldmenu`
+### `--worldmenu
+
+`
 
 Enables the world menu in the map-sharing code.
 
-## User directories
+### `
 
-### `--userdir <path>`
+`
+
+User directories.
+
+### `--userdir <path>
+
+`
 
 Base path for user-overrides to files from the ./data directory and named below.
 
-### `--savedir <directory name>`
+### `--savedir <directory name>
+
+`
 
 Subdirectory for game saves.
 
-### `--configdir <directory name>`
+### `--configdir <directory name>
+
+`
 
 Subdirectory for game configuration.
 
-### `--memorialdir <directory name>`
+### `--memorialdir <directory name>
+
+`
 
 Subdirectory for memorials.
 
-### `--optionfile <filename>`
+### `--optionfile <filename>
+
+`
 
 Name of the options file within the configdir.

--- a/docs/en/dev/reference/cli_options.md
+++ b/docs/en/dev/reference/cli_options.md
@@ -15,176 +15,112 @@ but also provides a number of command line options to help modders and developer
 
 ## Info
 
-### `--help
-
-`
+### `--help`
 
 print this message and exit.
 
-### `--version
-
-`
+### `--version`
 
 print the version and exit.
 
-### `--paths
-
-`
+### `--paths`
 
 print the paths used by the game and exit.
 
-### `
+## Command line parameters
 
-`
-
-Command line parameters:.
-
-### `--seed <string of letters and or numbers>
-
-`
+### `--seed <string of letters and or numbers>`
 
 Sets the random number generator's seed value.
 
-### `--jsonverify
-
-`
+### `--jsonverify`
 
 Checks the BN json files.
 
-### `--check-mods [mods…]
-
-`
+### `--check-mods [mods…]`
 
 Checks the json files belonging to BN mods.
 
-### `--dump-stats <what> [mode = TSV] [opts…]
-
-`
+### `--dump-stats <what> [mode = TSV] [opts…]`
 
 Dumps item stats.
 
-### `--world <name>
-
-`
+### `--world <name>`
 
 Load world.
 
-### `--basepath <path>
-
-`
+### `--basepath <path>`
 
 Base path for all game data subdirectories.
 
-### `--dont-debugmsg
-
-`
+### `--dont-debugmsg`
 
 If set, no debug messages will be printed.
 
-### `--lua-doc <output path>
-
-`
+### `--lua-doc <output path>`
 
 Generate Lua docs to given path and exit.
 
-### `--lua-types <output path>
-
-`
+### `--lua-types <output path>`
 
 Generate Lua types to given path and exit.
 
-### `--datadir <directory name>
-
-`
+### `--datadir <directory name>`
 
 Sub directory from which game data is loaded.
 
-### `--autopickupfile <filename>
-
-`
+### `--autopickupfile <filename>`
 
 Name of the autopickup options file within the configdir.
 
-### `--motdfile <filename>
-
-`
+### `--motdfile <filename>`
 
 Name of the message of the day file within the motd directory.
 
-### `
+## Map sharing
 
-`
-
-Map sharing.
-
-### `--shared
-
-`
+### `--shared`
 
 Activates the map-sharing mode.
 
-### `--username <name>
-
-`
+### `--username <name>`
 
 Instructs map-sharing code to use this name for your character..
 
-### `--addadmin <username>
-
-`
+### `--addadmin <username>`
 
 Instructs map-sharing code to use this name for your character and give you access to the cheat functions..
 
-### `--adddebugger <username>
-
-`
+### `--adddebugger <username>`
 
 Informs map-sharing code that you're running inside a debugger.
 
-### `--competitive
-
-`
+### `--competitive`
 
 Instructs map-sharing code to disable access to the in-game cheat functions.
 
-### `--worldmenu
-
-`
+### `--worldmenu`
 
 Enables the world menu in the map-sharing code.
 
-### `
+## User directories
 
-`
-
-User directories.
-
-### `--userdir <path>
-
-`
+### `--userdir <path>`
 
 Base path for user-overrides to files from the ./data directory and named below.
 
-### `--savedir <directory name>
-
-`
+### `--savedir <directory name>`
 
 Subdirectory for game saves.
 
-### `--configdir <directory name>
-
-`
+### `--configdir <directory name>`
 
 Subdirectory for game configuration.
 
-### `--memorialdir <directory name>
-
-`
+### `--memorialdir <directory name>`
 
 Subdirectory for memorials.
 
-### `--optionfile <filename>
-
-`
+### `--optionfile <filename>`
 
 Name of the options file within the configdir.

--- a/launch.vs.json
+++ b/launch.vs.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.2.1",
+  "configurations": [
+    {
+      "type": "default",
+      "project": "CMakeLists.txt",
+      "projectTarget": "cataclysm-bn-tiles.exe (src\\cataclysm-bn-tiles.exe)",
+      "name": "cataclysm-bn-tiles",
+      "currentDir": "${workspaceRoot}"
+    },
+    {
+      "type": "default",
+      "project": "CMakeLists.txt",
+      "projectTarget": "cata_test-tiles.exe (tests\\cata_test-tiles.exe)",
+      "name": "cata_test-tiles",
+      "currentDir": "${workspaceRoot}"
+    }
+  ]
+}

--- a/scripts/gen_cli_docs.ts
+++ b/scripts/gen_cli_docs.ts
@@ -62,7 +62,9 @@ if (import.meta.main) {
     .option("-o, --output <output:string>", "Output file path", { required: true })
     .parse(Deno.args)
 
-  const command = new Deno.Command("./cataclysm-bn-tiles", { args: ["--help"] })
+  const command = new Deno.Command(Deno.env.get("CATA_EXE") ?? "./cataclysm-bn-tiles", {
+    args: ["--help"],
+  })
   const { stdout } = await command.output()
 
   const text = new TextDecoder().decode(stdout)

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,0 +1,222 @@
+<#
+.SYNOPSIS
+    One-time setup script for building Cataclysm: Bright Nights on Windows.
+
+.DESCRIPTION
+    Validates prerequisites (Visual Studio 2022, cmake, ninja, vcpkg, git) and runs
+    the initial CMake configure step for terminal/CLI builds.
+
+    Visual Studio IDE users do not need this script — VS configures itself
+    automatically from CMakeSettings.json when you open the project folder.
+
+    Run this from a plain PowerShell or VS Developer PowerShell prompt.
+    Does not require administrator privileges.
+
+.PARAMETER Preset
+    The CMake configure preset to use. Defaults to "windows-tiles-sounds-x64-msvc".
+    Use "windows-tiles-sounds-x64-msvc-tracy" to configure a Tracy-enabled build.
+
+.EXAMPLE
+    .\setup.ps1
+    .\setup.ps1 -Preset windows-tiles-sounds-x64-msvc-tracy
+#>
+
+param(
+    [string]$Preset = "windows-tiles-sounds-x64-msvc"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+function Write-Header([string]$Text) {
+    Write-Host ""
+    Write-Host "=== $Text ===" -ForegroundColor Cyan
+}
+
+function Write-Ok([string]$Text) {
+    Write-Host "  [OK]   $Text" -ForegroundColor Green
+}
+
+function Write-Fail([string]$Text) {
+    Write-Host "  [FAIL] $Text" -ForegroundColor Red
+}
+
+function Write-Info([string]$Text) {
+    Write-Host "         $Text" -ForegroundColor Gray
+}
+
+$allOk = $true
+$vsPath = $null
+
+# ---------------------------------------------------------------------------
+# Check: cmake
+# ---------------------------------------------------------------------------
+Write-Header "Checking prerequisites"
+
+$cmakeVersion = $null
+try {
+    $cmakeRaw = cmake --version 2>&1 | Select-Object -First 1
+    if ($cmakeRaw -match "cmake version (\d+\.\d+\.\d+)") {
+        $cmakeVersion = [version]$Matches[1]
+    }
+} catch {}
+
+if ($null -eq $cmakeVersion) {
+    Write-Fail "cmake not found in PATH."
+    Write-Info "Install cmake >= 3.24 from https://cmake.org/download/"
+    Write-Info "or via the Visual Studio installer: modify your VS install and add"
+    Write-Info "'C++ CMake tools for Windows' under Individual Components."
+    $allOk = $false
+} elseif ($cmakeVersion -lt [version]"3.24") {
+    Write-Fail "cmake $cmakeVersion is too old (need >= 3.24)."
+    Write-Info "Update cmake from https://cmake.org/download/"
+    $allOk = $false
+} else {
+    Write-Ok "cmake $cmakeVersion"
+}
+
+# ---------------------------------------------------------------------------
+# Check: Visual Studio 2022 with C++ workload
+# ---------------------------------------------------------------------------
+$vsWhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+
+if (-not (Test-Path $vsWhere)) {
+    Write-Fail "Visual Studio Installer not found."
+    Write-Info "Install Visual Studio 2022 from https://visualstudio.microsoft.com/"
+    Write-Info "Required workload: 'Desktop development with C++'"
+    $allOk = $false
+} else {
+    $vsPath = & $vsWhere -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath 2>&1
+    if (-not $vsPath -or $vsPath -match "^Error") {
+        Write-Fail "Visual Studio 2022 with C++ tools not found."
+        Write-Info "In the Visual Studio Installer, ensure the"
+        Write-Info "'Desktop development with C++' workload is installed."
+        $allOk = $false
+    } else {
+        $vsVersion = & $vsWhere -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property catalog_productDisplayVersion 2>&1
+        Write-Ok "Visual Studio $vsVersion at: $vsPath"
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Check: vcpkg
+# ---------------------------------------------------------------------------
+$vcpkgExe = $null
+
+if ($env:VCPKG_ROOT -and (Test-Path (Join-Path $env:VCPKG_ROOT "vcpkg.exe"))) {
+    $vcpkgExe = Join-Path $env:VCPKG_ROOT "vcpkg.exe"
+    Write-Ok "vcpkg (VCPKG_ROOT): $($env:VCPKG_ROOT)"
+} elseif ($vsPath -and (Test-Path $vsWhere)) {
+    # Try the vcpkg bundled with Visual Studio (VS 2022 17.6+).
+    $vsBundledVcpkg = Join-Path $vsPath "VC\vcpkg"
+    if (Test-Path (Join-Path $vsBundledVcpkg "vcpkg.exe")) {
+        $vcpkgExe = Join-Path $vsBundledVcpkg "vcpkg.exe"
+        $env:VCPKG_ROOT = $vsBundledVcpkg
+        Write-Ok "vcpkg (VS bundled): $vsBundledVcpkg"
+    }
+}
+
+if (-not $vcpkgExe) {
+    Write-Fail "vcpkg not found."
+    Write-Info "Option 1 (recommended): The VS installer includes vcpkg."
+    Write-Info "           In the VS installer, add 'C++ package manager: vcpkg'."
+    Write-Info "Option 2: Install vcpkg manually: https://vcpkg.io/en/getting-started.html"
+    Write-Info "           Then set the VCPKG_ROOT environment variable to its path."
+    $allOk = $false
+}
+
+# ---------------------------------------------------------------------------
+# Check: git
+# ---------------------------------------------------------------------------
+try {
+    $gitVersion = git --version 2>&1
+    Write-Ok "git: $gitVersion"
+} catch {
+    Write-Fail "git not found in PATH."
+    Write-Info "Install git from https://git-scm.com/ or via winget: winget install Git.Git"
+    $allOk = $false
+}
+
+# ---------------------------------------------------------------------------
+# Check: Ninja (required for Ninja Multi-Config generator)
+# Ninja ships with VS 2022 via "C++ CMake tools for Windows".
+# If it is not in PATH yet, find it from the VS install and add it so the
+# cmake --preset invocation below can locate the generator.
+# ---------------------------------------------------------------------------
+$ninjaCmd = Get-Command ninja -ErrorAction SilentlyContinue
+if ($ninjaCmd) {
+    $ninjaVersion = ninja --version 2>&1 | Select-Object -First 1
+    Write-Ok "ninja $ninjaVersion"
+} elseif ($vsPath) {
+    $vsNinjaDir = Join-Path $vsPath "Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja"
+    if (Test-Path (Join-Path $vsNinjaDir "ninja.exe")) {
+        $env:PATH = "$vsNinjaDir;$env:PATH"
+        $ninjaVersion = ninja --version 2>&1 | Select-Object -First 1
+        Write-Ok "ninja $ninjaVersion (VS bundled)"
+    } else {
+        Write-Fail "ninja not found."
+        Write-Info "Ninja ships with VS 2022 via the 'C++ CMake tools for Windows' component."
+        Write-Info "In the VS Installer, ensure 'C++ CMake tools for Windows' is installed."
+        $allOk = $false
+    }
+} else {
+    Write-Fail "ninja not found."
+    Write-Info "Ninja ships with VS 2022 via the 'C++ CMake tools for Windows' component."
+    Write-Info "In the VS Installer, ensure 'C++ CMake tools for Windows' is installed."
+    $allOk = $false
+}
+
+# ---------------------------------------------------------------------------
+# Bail out if prerequisites are missing
+# ---------------------------------------------------------------------------
+if (-not $allOk) {
+    Write-Host ""
+    Write-Host "One or more prerequisites are missing. Fix the issues above and re-run setup.ps1." -ForegroundColor Red
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Run cmake configure
+# ---------------------------------------------------------------------------
+Write-Header "Running CMake configure"
+Write-Host "  Preset : $Preset"
+Write-Host "  Output : out/build/$Preset"
+Write-Host ""
+
+cmake --preset $Preset
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Host ""
+    Write-Fail "CMake configure failed (exit code $LASTEXITCODE)."
+    Write-Host ""
+    Write-Host "Common fixes:" -ForegroundColor Yellow
+    Write-Host "  - Delete out\build\$Preset and run setup.ps1 again."
+    Write-Host "  - Run setup.ps1 from a VS 2022 Developer PowerShell prompt."
+    Write-Host "  - Check that VCPKG_ROOT points to a valid vcpkg installation."
+    Write-Host "  - Verify your internet connection (vcpkg downloads packages on first run)."
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Success
+# ---------------------------------------------------------------------------
+Write-Host ""
+Write-Header "Setup complete"
+Write-Ok "CMake configured successfully."
+Write-Host ""
+Write-Host "Terminal build commands:" -ForegroundColor Yellow
+Write-Host "  cmake --build --preset windows-msvc-relwithdebinfo"
+Write-Host "  cmake --build --preset windows-msvc-debug"
+Write-Host "  cmake --build --preset windows-msvc-release"
+Write-Host ""
+Write-Host "Visual Studio IDE:" -ForegroundColor Yellow
+Write-Host "  setup.ps1 is not required for the VS IDE workflow."
+Write-Host "  Open this folder in VS 2022 (File > Open > Folder) and"
+Write-Host "  select a configuration from the toolbar: Debug, RelWithDebInfo,"
+Write-Host "  Release, Tests, or Tracy."
+Write-Host ""
+Write-Host "See docs/en/dev/guides/building/vs_cmake.md for full details."
+Write-Host ""

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,7 +176,7 @@ if (TILES)
     if( LUA_DOCS_ON_BUILD AND DENO_BINARY )
         add_custom_command(
             TARGET cataclysm-bn-tiles POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E env --unset=LD_LIBRARY_PATH ${DENO_BINARY} task docs:gen
+            COMMAND ${CMAKE_COMMAND} -E env --unset=LD_LIBRARY_PATH "CATA_EXE=$<TARGET_FILE:cataclysm-bn-tiles>" ${DENO_BINARY} task docs:gen
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
             COMMENT "Generating Lua reference/annotations (deno task docs:gen)"
             VERBATIM


### PR DESCRIPTION
## Purpose of change (The Why)

Still too fragile
Didn't work frequently, messy interface.

## Describe the solution (The How)

Use CMakeSettings.json instead of CMakePresets.json
FORCE Visual Studio to:
Only see Windows builds
Do exactly as we want
Update docs to match

## Describe alternatives you've considered

<img width="168" height="300" alt="image" src="https://github.com/user-attachments/assets/15d55b25-dc20-4897-8510-9d0fd6444b55" />

## Testing

Everything seems to work.
Famous last words

Alright, but seriously. I've tested this a good amount, but with this sort of thing it needs more than that.
I can run, debug, build, etc.
But trial by fire is the only way.
We'll simply have to see.

## Additional context

Note, this setting must be set correctly:
<img width="905" height="434" alt="devenv_rckvoUJXJs" src="https://github.com/user-attachments/assets/1e85cae2-8854-4432-a09d-f415d8a12d65" />
<img width="390" height="104" alt="devenv_kNAhT5TNr3" src="https://github.com/user-attachments/assets/3af8acb9-2ae3-40c8-8e0a-03cf96aa3d59" />


You can see how much cleaner the lists are:
<img width="819" height="205" alt="devenv_rRAlyqUW1B" src="https://github.com/user-attachments/assets/0e1e1ce0-23c3-452c-97bf-b9d02bf7b980" />
<img width="738" height="209" alt="devenv_PsGuQHz0Ue" src="https://github.com/user-attachments/assets/4698b0eb-fa67-47b5-a1d3-64858ca2b43e" />

This makes adding a few more convenience entries is more reasonable.