### PR TITLE
build: Fix Windows Workflow

### DIFF
--- a/.github/workflows/msvc-full-features-cmake.yml
+++ b/.github/workflows/msvc-full-features-cmake.yml
@@ -62,6 +62,11 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Setup MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
       - name: Remove Strawberry Perl from PATH
         run: |
           echo $env:PATH

--- a/.github/workflows/msvc-full-features-cmake.yml
+++ b/.github/workflows/msvc-full-features-cmake.yml
@@ -1,6 +1,7 @@
 name: Cataclysm Windows build (CMake + MSVC)
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/msvc-full-features-cmake.yml
+++ b/.github/workflows/msvc-full-features-cmake.yml
@@ -47,7 +47,7 @@ env:
   # Have to use github.workspace because runner namespace isn't available yet.
   VCPKG_OVERLAY_TRIPLETS: ${{ github.workspace }}\.github\vcpkg_triplets
   ZSTD_CLEVEL: 17
-  CMAKE_PRESET: windows-tiles-sounds-x64-msvc
+  CMAKE_BUILD_DIR: out/build/windows-tiles-sounds-x64-msvc-tests
 
 jobs:
   build_catatclysm:
@@ -60,11 +60,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
-        with:
-          vs-version: 17.13
 
       - name: Remove Strawberry Perl from PATH
         run: |
@@ -108,11 +103,11 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: msvc-cmake-${{ env.CMAKE_PRESET }}-${{ github.ref_name }}
+          key: msvc-cmake-windows-tiles-sounds-x64-msvc-${{ github.ref_name }}
           restore-keys: |
-            msvc-cmake-${{ env.CMAKE_PRESET }}-${{ github.ref_name }}
-            msvc-cmake-${{ env.CMAKE_PRESET }}-main
-            msvc-cmake-${{ env.CMAKE_PRESET }}-
+            msvc-cmake-windows-tiles-sounds-x64-msvc-${{ github.ref_name }}
+            msvc-cmake-windows-tiles-sounds-x64-msvc-main
+            msvc-cmake-windows-tiles-sounds-x64-msvc-
           max-size: 500M
           verbose: 2
           save: ${{ github.event_name != 'pull_request' }}
@@ -123,23 +118,43 @@ jobs:
           echo "CCACHE_SLOPPINESS=include_file_ctime,include_file_mtime,time_macros,pch_defines" >> $env:GITHUB_ENV
           echo "CCACHE_NOHASHDIR=1" >> $env:GITHUB_ENV
 
-      - name: Configure and Build
-        uses: lukka/run-cmake@v10
-        with:
-          configurePreset: ${{ env.CMAKE_PRESET }}
-          buildPreset: windows-msvc-build
-          buildPresetAdditionalArgs: "['--config', 'RelWithDebInfo']"
+      # build-scripts/windows-tiles-sounds-x64-msvc.cmake (CMAKE_PROJECT_INCLUDE_BEFORE)
+      # bootstraps the MSVC toolchain via VsDevCmd.bat if not already in a VS environment,
+      # and auto-detects ccache if present on PATH.
+      - name: Configure CMake
+        run: |
+          cmake -G Ninja `
+            -S "${{ github.workspace }}" `
+            -B "${{ github.workspace }}/${{ env.CMAKE_BUILD_DIR }}" `
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo `
+            -DCMAKE_PROJECT_INCLUDE_BEFORE="${{ github.workspace }}/build-scripts/windows-tiles-sounds-x64-msvc.cmake" `
+            -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}/build-scripts/MSVC.cmake" `
+            -DVCPKG_TARGET_TRIPLET=x64-windows-static `
+            -DDYNAMIC_LINKING=False `
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON `
+            -DCURSES=False `
+            -DLOCALIZE=True `
+            -DTILES=True `
+            -DSOUND=True `
+            -DTESTS=True `
+            -DJSON_FORMAT=OFF `
+            -DCMAKE_INSTALL_MESSAGE=NEVER
+
+      - name: Build
+        run: |
+          cmake --build "${{ github.workspace }}/${{ env.CMAKE_BUILD_DIR }}" `
+            --target cataclysm-bn-tiles --target cata_test-tiles
 
       - name: Dump logs if build failed
         if: failure()
         run: |
           echo =================================================
-          Get-ChildItem "${{ runner.workspace }}/Cataclysm-BN/out/build/$env:CMAKE_PRESET" -Recurse
+          Get-ChildItem "${{ github.workspace }}/${{ env.CMAKE_BUILD_DIR }}" -Recurse
           echo =================================================
 
       - name: Compile .mo files for localization
         run: |
-          cmake --build out/build/$env:CMAKE_PRESET --target translations_compile --config RelWithDebInfo
+          cmake --build "${{ github.workspace }}/${{ env.CMAKE_BUILD_DIR }}" --target translations_compile
 
       - name: ccache stats
         run: |
@@ -147,4 +162,4 @@ jobs:
 
       - name: Run tests
         run: |
-          & "out/build/$env:CMAKE_PRESET/tests/RelWithDebInfo/cata_test-tiles.exe" --rng-seed time
+          & "${{ github.workspace }}/${{ env.CMAKE_BUILD_DIR }}/tests/cata_test-tiles.exe" --rng-seed time

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,13 +2,13 @@ set(MAIN_CPP ${CMAKE_SOURCE_DIR}/src/main.cpp)
 set(MESSAGES_CPP ${CMAKE_SOURCE_DIR}/src/messages.cpp)
 set(RESOURCE_RC ${CMAKE_SOURCE_DIR}/src/resource.rc)
 
-file(GLOB CATACLYSM_BN_SOURCES ${CMAKE_SOURCE_DIR}/src/*.cpp)
+file(GLOB CATACLYSM_BN_SOURCES CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/src/*.cpp)
 
 list(REMOVE_ITEM CATACLYSM_BN_SOURCES ${MAIN_CPP} ${MESSAGES_CPP})
 
 # Lua binding translation units are template-heavy and primarily run at startup;
 # compile them with no optimization to reduce build times.
-file(GLOB CATALUA_BINDINGS_SOURCES ${CMAKE_SOURCE_DIR}/src/catalua_bindings*.cpp)
+file(GLOB CATALUA_BINDINGS_SOURCES CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/src/catalua_bindings*.cpp)
 if (MSVC)
     set(CATALUA_BINDINGS_COMPILE_OPTIONS /Od)
 else ()
@@ -18,7 +18,7 @@ foreach (catalua_src IN LISTS CATALUA_BINDINGS_SOURCES)
     set_source_files_properties(${catalua_src} PROPERTIES COMPILE_OPTIONS "${CATALUA_BINDINGS_COMPILE_OPTIONS}")
 endforeach ()
 
-file(GLOB CATACLYSM_BN_HEADERS ${CMAKE_SOURCE_DIR}/src/*.h)
+file(GLOB CATACLYSM_BN_HEADERS CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/src/*.h)
 
 add_subdirectory(lua)
 add_subdirectory(sol)


### PR DESCRIPTION
## Purpose of change (The Why)

Fixing Windows workflow to use CMakeSettings.json instead of CMakePresets, which is currently broken and doesn't support Ninja properly.

## Describe the solution (The How)

Update the workflow file.
Also fix configuration cache rebuild detection that I missed.

## Describe alternatives you've considered

Trying to make CMakePresets.json work *again*.

## Testing

Ran workflow, compiles via Github actions