### PR TITLE
ci: verify PR title action on fork

### DIFF
--- a/.github/workflows/verify-pr-title-action.yml
+++ b/.github/workflows/verify-pr-title-action.yml
@@ -1,0 +1,41 @@
+name: Verify PR Title Action
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: Pull request number to simulate
+        required: true
+        type: string
+      pr-title:
+        description: Pull request title to validate
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  verify:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Write simulated event payload
+        shell: bash
+        run: |
+          cat > event.json <<EOF
+          {
+            "pull_request": {
+              "number": ${{ inputs.pr-number }},
+              "title": "${{ inputs.pr-title }}"
+            }
+          }
+          EOF
+
+      - uses: scarf005/conventional-prs@v0.5.0
+        env:
+          GITHUB_EVENT_NAME: pull_request_target
+          GITHUB_EVENT_PATH: ${{ github.workspace }}/event.json
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        with: { github-token: "${{ secrets.GITHUB_TOKEN }}" }


### PR DESCRIPTION
## Purpose of change (The Why)

Temporary fork PR to verify the updated PR title workflow from `ci/pr-title-action`.

## Describe the solution (The How)

Open a draft PR against the branch that contains the new action-based workflow.

## Describe alternatives you've considered

## Testing

- Trigger fork `Validate PR Title` on PR open against `ci/pr-title-action`.

## Additional context

- Temporary verification PR; will be closed after the workflow completes.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
